### PR TITLE
Add init: false in config.json

### DIFF
--- a/backup-s3/config.json
+++ b/backup-s3/config.json
@@ -11,6 +11,7 @@
     "awssecret": "",
     "bucketname": ""
   },
+  "init": "false",
   "schema": {
     "awskey": "str",
     "awssecret": "str",


### PR DESCRIPTION
As written in the doc, this is now necessary to ix issue "s6-overlay-suexec: fatal: can only run as pid 1"
Reference: https://developers.home-assistant.io/blog/2022/05/12/s6-overlay-base-images/